### PR TITLE
PHP 8.0 compatibility change

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -40,7 +40,7 @@ class Parser {
      * @param string $line
      */
     private function parseLine($line) {
-        switch($line{0}) {
+        switch($line[0]) {
             case '#':
                 $this->parseTitle($line);
                 break;

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -55,7 +55,7 @@ class Parser {
      */
     private function parseTitle($line) {
         for($i = 0; $i < 3; ++$i) {
-            if($line{$i} !== '#') {
+            if($line[$i] !== '#') {
                 break;
             }
         }


### PR DESCRIPTION
Array access with curly braces is no longer allowed as of PHP 8.0.
Small change for compatibility.